### PR TITLE
Create ability to have an agent extra configuration directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Zabbix Agent(Optional)
 #####
 * `zabbix_agent_listen_port`
 * `zabbix_agent_hostname`
+* `zabbix_agent_extra_config`
 
 Zabbix Agent Log(Optional)
 #####

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ zabbix_agent_listen_port: 10050
 zabbix_agent_hostname: "{{ ansible_hostname }}"
 zabbix_agent_host_metadata:
   - "Linux"
+zabbix_agent_extra_config_path: /etc/zabbix/zabbix_agentd.d
 zabbix_agent_extra_config: []
   # - parameter: ""
   #   value: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,11 @@ zabbix_agent_listen_port: 10050
 zabbix_agent_hostname: "{{ ansible_hostname }}"
 zabbix_agent_host_metadata:
   - "Linux"
+zabbix_agent_extra_config: []
+  # - parameter: ""
+  #   value: ""
+  # - parameter: ""
+  #   value: ""
 
 zabbix_agent_log_type: file
 zabbix_agent_log_file: /var/log/zabbix/zabbix_agentd.log

--- a/tasks/install-agent.yml
+++ b/tasks/install-agent.yml
@@ -34,7 +34,7 @@
 
 - name: Create Zabbix Agent extra config directory
   file:
-    path: "/etc/zabbix/zabbix_agentd.d"
+    path: "{{ zabbix_agent_extra_config_path }}"
     owner: root
     group: root
     mode: 0750
@@ -54,7 +54,7 @@
 - name: Put in place Zabbix Agent extra config file
   template:
     src: "zabbix-extra.conf.j2"
-    dest: "/etc/zabbix/zabbix_agentd.d/extra-params.conf"
+    dest: "{{ zabbix_agent_extra_config_path }}/extra-params.conf"
     owner: root
     group: root
     mode: 0640

--- a/tasks/install-agent.yml
+++ b/tasks/install-agent.yml
@@ -32,6 +32,14 @@
     enabled: yes
   notify: Start Zabbix Agent
 
+- name: Create Zabbix Agent extra config directory
+  file:
+    path: "/etc/zabbix/zabbix_agentd.d"
+    owner: root
+    group: root
+    mode: 0750
+    state: directory
+
 - name: Put Zabbix Agent config in place
   template:
     src: zabbix-agent.conf.j2
@@ -42,3 +50,15 @@
   notify: Restart Zabbix Agent
   tags:
     - agent-config-file
+
+- name: Put in place Zabbix Agent extra config file
+  template:
+    src: "zabbix-extra.conf.j2"
+    dest: "/etc/zabbix/zabbix_agentd.d/extra-params.conf"
+    owner: root
+    group: root
+    mode: 0640
+  when: zabbix_agent_extra_config | length > 0
+  notify: Restart Zabbix Agent
+  tags:
+    - agent-extra-configs

--- a/tasks/install-agent.yml
+++ b/tasks/install-agent.yml
@@ -35,8 +35,8 @@
 - name: Create Zabbix Agent extra config directory
   file:
     path: "{{ zabbix_agent_extra_config_path }}"
-    owner: root
-    group: root
+    owner: zabbix
+    group: zabbix
     mode: 0750
     state: directory
 
@@ -55,8 +55,8 @@
   template:
     src: "zabbix-extra.conf.j2"
     dest: "{{ zabbix_agent_extra_config_path }}/extra-params.conf"
-    owner: root
-    group: root
+    owner: zabbix
+    group: zabbix
     mode: 0640
   when: zabbix_agent_extra_config | length > 0
   notify: Restart Zabbix Agent

--- a/templates/zabbix-agent.conf.j2
+++ b/templates/zabbix-agent.conf.j2
@@ -6,7 +6,7 @@ ListenPort={{ zabbix_agent_listen_port }}
 Hostname={{ zabbix_agent_hostname }}
 ServerActive={{ zabbix_agent_server_active | join(',') }}
 HostMetadata={{ zabbix_agent_host_metadata | join(' ') }}
-HostMetadataItem=system.uname
+Include=/etc/zabbix/zabbix_agentd.d/*.conf
 
 ### Agent Encryption settings
 {% if zabbix_agent_encrypt is sameas true %}

--- a/templates/zabbix-agent.conf.j2
+++ b/templates/zabbix-agent.conf.j2
@@ -6,7 +6,7 @@ ListenPort={{ zabbix_agent_listen_port }}
 Hostname={{ zabbix_agent_hostname }}
 ServerActive={{ zabbix_agent_server_active | join(',') }}
 HostMetadata={{ zabbix_agent_host_metadata | join(' ') }}
-Include=/etc/zabbix/zabbix_agentd.d/*.conf
+Include={{ zabbix_agent_extra_config_path }}/*.conf
 
 ### Agent Encryption settings
 {% if zabbix_agent_encrypt is sameas true %}

--- a/templates/zabbix-extra.conf.j2
+++ b/templates/zabbix-extra.conf.j2
@@ -1,0 +1,5 @@
+# Ansible Managed File - Do Not Edit
+
+{% for param in zabbix_agent_extra_config %}
+{{ param.parameter }}={{ param.value }}
+{% endfor %}


### PR DESCRIPTION
There may circumstances where we want to put in place zabbix agent extra configuration. 

The most relevant example is putting in place the `UserParameter` entry so we can define custom checks on a per server basis. 