### PR TITLE
Include variables for additional host metadata values in agent config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ zabbix_agent_listen_port: 10050
 zabbix_agent_hostname: "{{ ansible_hostname }}"
 zabbix_agent_host_metadata:
   - "Linux"
+zabbix_agent_host_metadata_addtl: []
 zabbix_agent_extra_config_path: /etc/zabbix/zabbix_agentd.d
 zabbix_agent_extra_config: []
   # - parameter: ""

--- a/templates/zabbix-agent.conf.j2
+++ b/templates/zabbix-agent.conf.j2
@@ -5,7 +5,7 @@ Server={{ zabbix_agent_server }}
 ListenPort={{ zabbix_agent_listen_port }}
 Hostname={{ zabbix_agent_hostname }}
 ServerActive={{ zabbix_agent_server_active | join(',') }}
-HostMetadata={{ zabbix_agent_host_metadata | join(' ') }}
+HostMetadata={{ zabbix_agent_host_metadata | join(' ') }} {{ zabbix_agent_host_metadata_addtl | join(' ') }}
 Include={{ zabbix_agent_extra_config_path }}/*.conf
 
 ### Agent Encryption settings


### PR DESCRIPTION
This puts in place the ability to create additional HostMetadata values that we can use to categorize hosts and hopefully be able to use auto-registration to dynamically assign hosts to groups/checks. 