### PR TITLE
Change from include_tasks to import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
-- include_tasks: setup-vars.yml
+- import_tasks: setup-vars.yml
 
-- include_tasks: install-repo.yml
+- import_tasks: install-repo.yml
 
-- include_tasks: install-agent.yml
+- import_tasks: install-agent.yml
 
-- include_tasks: install-server.yml
+- import_tasks: install-server.yml
   when: zabbix_install_server
 
-- include_tasks: install-server-web.yml
+- import_tasks: install-server-web.yml
   when: zabbix_install_server
 
-- include_tasks: init-db.yml
+- import_tasks: init-db.yml
   when: zabbix_install_server


### PR DESCRIPTION
In more recent versions of ansible, we typically want to use `import_tasks` instead of `include_tasks`.

Reference: https://docs.ansible.com/ansible/devel/user_guide/playbooks_reuse.html#dynamic-vs-static