### PR TITLE
Update agent config to allow system.run item key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ zabbix_vhost_config:
 
 ### Zabbix Agent Configuration Parameters
 zabbix_agent_pid_file_path: /var/run/zabbix/zabbix_agentd.pid
-zabbix_agent_deny_key: "system.run[*]"
+zabbix_agent_allow_key: "system.run[*]"
 zabbix_agent_server: 127.0.0.1
 zabbix_agent_server_active:
   - 127.0.0.1

--- a/templates/zabbix-agent.conf.j2
+++ b/templates/zabbix-agent.conf.j2
@@ -1,6 +1,6 @@
 ### General Zabbix Agent Settings
 PidFile={{ zabbix_agent_pid_file_path }}
-DenyKey={{ zabbix_agent_deny_key }}
+AllowKey={{ zabbix_agent_allow_key }}
 Server={{ zabbix_agent_server }}
 ListenPort={{ zabbix_agent_listen_port }}
 Hostname={{ zabbix_agent_hostname }}


### PR DESCRIPTION
Allowing the item key system.run[*] to be able to configure Zabbix Actions that run remote commands via the agents. 