### PR TITLE
Add network share availability check

### DIFF
--- a/files/check_network_shares
+++ b/files/check_network_shares
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+cd / || exit 1
+
+fail() {
+  printf "1"
+}
+
+# remove comments; remove blank lines; normalize spacing to a single space
+# select mount point and filesystem
+# ensure expected filesystem matches actual filesystem for network filesystems
+# timeout prevents a stale NFS share from freezing the check
+
+# Skips "noauto" filesystems, but will also skip "noauto_da_alloc". As
+# "noauto_da_alloc" applies only to ext4, this won't be a problem in practice.
+
+# Due to the use of pipes, the while opperates in a subshell, so there
+# is no communication to outside the loop. Each failed share will prepend
+# a "1" to the 0, still providing a value greater than 0 and can allow
+# something more sophisticated to count the number of failed shares.
+
+sed -re 's/#.*//; /^$/d; s/\s+/ /g' /etc/fstab \
+  | cut -f2-4 '-d ' \
+  | while read -r fs type options; do
+      if [ "$type" != "nfs" ] && [ "$type" != "cifs" ]; then continue; fi
+      case $options in *noauto*) continue ;; esac
+
+      state="$(timeout -s 9 10 stat -f -c '%T' "$fs")"
+      if [ "$type" != "$state" ]; then fail; fi
+done
+
+echo 0

--- a/tasks/install-agent.yml
+++ b/tasks/install-agent.yml
@@ -51,6 +51,18 @@
   tags:
     - agent-config-file
 
+- name: Put in place Zabbix Agent Helper Scripts
+  copy:
+    src: "{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - check_network_shares
+  tags:
+    - agent-helper-scripts
+
 - name: Put in place Zabbix Agent extra config file
   template:
     src: "zabbix-extra.conf.j2"

--- a/tasks/install-server-web.yml
+++ b/tasks/install-server-web.yml
@@ -4,6 +4,9 @@
   ini_file:
     dest: /etc/yum.repos.d/zabbix.repo
     section: zabbix-frontend
+    owner: root
+    group: root
+    mode: "0644"
     option: enabled
     value: "1"
 


### PR DESCRIPTION
Checks all automatically mounted nfs/cifs shares to ensure they are,
indeed, nfs/cifs mounts.

It is a simplistic check, so a higher nfs/cifs mountpoint can mask
problems with a lower nfs/cifs mount.